### PR TITLE
Feat 12 & 15 (Api admin ctrl, Angular auth)

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,11 +84,10 @@ const estates = require(`${apiRoot}/estates`);
 const projects = require(`${apiRoot}/projects`);
 
 const api = '/api';
-app.use(`${api}`, index);
 app.use(`${api}/admin`, admin);
 app.use(`${api}/projects`, projects);
 app.use(`${api}/estates`, estates);
-
+app.use(`${api}`, index); // MUST BE LAST ROUTE!
 
 /////////////////////////////
 //      CLIENT ROUTER      //
@@ -111,6 +110,11 @@ app.use((err, req, res, next) => {
     if ((req.app.get('env') === 'development') && err.stack) {
         e.stack = err.stack;
     }
+
+    if (err.description) {
+        e.description = err.description;
+    }
+
     // render the error page
     res.status(err.status || 500)
         .json(e);

--- a/client/src/app/admin/admin.component.html
+++ b/client/src/app/admin/admin.component.html
@@ -1,0 +1,5 @@
+<section>
+    <h3>Hello admin</h3>
+
+    <p>Welcome to admin</p>
+</section>

--- a/client/src/app/admin/admin.component.ts
+++ b/client/src/app/admin/admin.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'app-admin',
+    templateUrl: './admin.component.html',
+    styleUrls: ['./admin.component.scss']
+})
+export class AdminComponent implements OnInit{
+
+    constructor() {}
+
+    ngOnInit(): void {
+
+    }
+}

--- a/client/src/app/admin/index.ts
+++ b/client/src/app/admin/index.ts
@@ -1,0 +1,10 @@
+import { AdminComponent } from './admin.component';
+
+
+export const ADMIN_DECLARATIONS = [
+    AdminComponent
+];
+
+export const ADMIN_PROVIDERS = [
+
+];

--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -5,6 +5,8 @@ import { ProjectsComponent } from "./projects/projects.component";
 import { EstatesComponent } from "./estates/estates.component";
 import { ErrorComponent } from "./error/error.component";
 
+import { AuthGuard } from './shared/auth/auth.guard';
+import { AdminComponent } from './admin/admin.component';
 
 const routes:Routes = [
     {
@@ -18,6 +20,11 @@ const routes:Routes = [
     {
         path: 'estates',
         component: EstatesComponent
+    },
+    {
+        path: 'admin',
+        component: AdminComponent,
+        canActivate: [ AuthGuard ] // Protects routes from unauthorized access
     },
     { path: '**', component: ErrorComponent }
 ];

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -9,22 +9,30 @@ import { AppRoutingModule } from "./app-routing.module";
 import { ProjectsComponent } from './projects/projects.component';
 import { EstatesComponent } from './estates/estates.component';
 import { ERROR_DECLARATIONS } from './error';
+import { SHARED_DECLARATIONS, SHARED_PROVIDERS } from './shared';
+import { ADMIN_DECLARATIONS, ADMIN_PROVIDERS } from './admin/index';
 
 @NgModule({
-  declarations: [
-    AppComponent,
-    DashboardComponent,
-    ProjectsComponent,
-    EstatesComponent,
-    ...ERROR_DECLARATIONS
-  ],
-  imports: [
-    BrowserModule,
-    FormsModule,
-    HttpModule,
-    AppRoutingModule
-  ],
-  providers: [],
-  bootstrap: [AppComponent]
+    declarations: [
+        AppComponent,
+        DashboardComponent,
+        ProjectsComponent,
+        EstatesComponent,
+        ...ERROR_DECLARATIONS,
+        ...SHARED_DECLARATIONS,
+        ...ADMIN_DECLARATIONS
+    ],
+    imports: [
+        BrowserModule,
+        FormsModule,
+        HttpModule,
+        AppRoutingModule
+    ],
+    providers: [
+        ...SHARED_PROVIDERS,
+        ...ADMIN_PROVIDERS
+    ],
+    bootstrap: [ AppComponent ]
 })
-export class AppModule { }
+export class AppModule {
+}

--- a/client/src/app/shared/auth/auth.guard.ts
+++ b/client/src/app/shared/auth/auth.guard.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Router, CanActivate } from '@angular/router';
+import { AuthService } from './auth.service';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+
+    constructor(private auth: AuthService,
+                private router: Router) { }
+
+    canActivate(): boolean {
+        let authenticated = this.auth.authenticated();
+
+        if (!authenticated) {
+            // Do some rerouting
+            //this.router.navigate(['']);
+        }
+
+        return authenticated; // Can ativate if authenticated
+    }
+}

--- a/client/src/app/shared/auth/auth.service.ts
+++ b/client/src/app/shared/auth/auth.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+import { Http, Headers } from '@angular/http';
+
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import 'rxjs/add/operator/map';
+
+@Injectable()
+export class AuthService {
+    private tokenKey: string = 'ch_token';
+    private authUrl: string = '/api/admin/token';
+    private authValChange = new BehaviorSubject<boolean>(false);
+    authStatus = this.authValChange.asObservable();
+
+    constructor(private http: Http) {
+        this.updateAuth();
+    }
+
+    authenticate(email: string, password: string): Promise<boolean> {
+        return new Promise((rsv, rr) => {
+            this.http.post(this.authUrl, { email, password })
+                .map(res => res.json())
+                .subscribe((data) => {
+                    localStorage.setItem(this.tokenKey, data.token);
+                    this.updateAuth();
+                    rsv(true);
+                }, err => rr(err));
+        });
+    }
+
+    /**
+     * Removes the token from localStorage, whereas the admin
+     * can no longer call protected routes, thus logging him out.
+     * */
+    logout(): void {
+        localStorage.removeItem(this.tokenKey);
+        this.updateAuth();
+    }
+
+    getToken(): string {
+        return localStorage.getItem(this.tokenKey);
+    }
+
+    /**
+     * When other services would like to
+     * send HTTP-request, a header containing a token is usually
+     * required. This method can be called to get this header
+     * @return {Headers}
+     * */
+    getAuthHeader(): Headers {
+        const headers = new Headers();
+        headers.append('Authorization', this.getToken());
+        return headers;
+    }
+
+    /**
+     * Checks if user is authenticated or not
+     * @return {boolean}
+     * */
+    authenticated(): boolean {
+        return !!localStorage.getItem(this.tokenKey); // Uses !! to force value to be a boolean
+    }
+
+    /**
+     * Updates the value in the authStatus property, which
+     * components can subscribe on. Giving them a running status
+     * on the user authentication
+     * */
+    updateAuth() {
+        this.authValChange.next(this.authenticated());
+    }
+}

--- a/client/src/app/shared/index.ts
+++ b/client/src/app/shared/index.ts
@@ -1,0 +1,9 @@
+import { AuthService } from './auth/auth.service';
+import { AuthGuard } from './auth/auth.guard';
+
+export const SHARED_DECLARATIONS = [];
+
+export const SHARED_PROVIDERS = [
+    AuthService,
+    AuthGuard
+];

--- a/controllers/admin/findByUid.js
+++ b/controllers/admin/findByUid.js
@@ -1,0 +1,46 @@
+const Admin = require('../../models/admin');
+
+const findByUid = [validateUid, findAdmin, returnAdmin];
+
+function validateUid (req, res, next) {
+    const { uid } = req.decoded;
+
+    if (!uid) {
+        const err = new Error('[Admin Error] Cannot find uid. Please ensure you are authenticated');
+        err.status = 400;
+        return next(err);
+    }
+    next();
+}
+
+function findAdmin (req, res, next) {
+    const { uid } = req.decoded;
+
+    Admin.findById(uid)
+        .then((admin) => {
+            if (!admin) {
+                const err = new Error('[Admin Error] Cannot find current, logged in, admin');
+                err.status = 500;
+                return next(err);
+            }
+
+            req.admin = admin;
+            next();
+        })
+        .catch(err => next(err));
+}
+
+function returnAdmin ({ admin }, res, next) {
+    const { _id, firstName, lastName, email, lastActive, created } = admin;
+
+    res.status(200).json({
+        _id,
+        firstName,
+        lastName,
+        email,
+        lastActive,
+        created
+    });
+}
+
+module.exports = { findByUid };

--- a/controllers/admin/findByUid.js
+++ b/controllers/admin/findByUid.js
@@ -1,5 +1,6 @@
 const Admin = require('../../models/admin');
 
+
 const findByUid = [validateUid, findAdmin, returnAdmin];
 
 function validateUid (req, res, next) {

--- a/controllers/admin/index.js
+++ b/controllers/admin/index.js
@@ -4,14 +4,15 @@ const { requireToken } = require('../../middleware/auth');
 const { authenticate } = require('./token');
 const { register } = require('./register');
 const { update } = require('./update');
+const { findByUid } = require('./findByUid');
+const { remove } = require('./remove');
 
-router.get('/', (req, res, next) => {
 
-    res.status(200).json({title: 'Admin'});
-});
-
+router.get('/', requireToken, findByUid);
 router.post('/token', authenticate);
 router.post('/register', register);
 router.put('/', requireToken, update);
+router.delete('/', requireToken, remove);
+
 
 module.exports = router;

--- a/controllers/admin/register.js
+++ b/controllers/admin/register.js
@@ -1,8 +1,9 @@
 const Admin = require('../../models/admin');
-const { generateToken }= require('./token');
+const { generateToken } = require('./token');
 
 const register = [
     validateFields,
+    validatePassword,
     saveAdmin,
     generateToken,
     returnAdmin
@@ -11,6 +12,7 @@ const register = [
 function validateFields (req, res, next) {
     const fields = ['firstName', 'lastName', 'email', 'password', 'confirmPassword'];
     const admin = {};
+
     for (let field of fields) {
         if (!req.body[field]) {
             const err = new Error(`[Registration Error] Missing one or more of the input fields ${fields.join(', ')}`);
@@ -21,13 +23,25 @@ function validateFields (req, res, next) {
         admin[field] = req.body[field]; // Set fields in admin object
     }
 
-    if (admin.password !== admin.confirmPassword) {
+    req.admin = admin;
+    next();
+}
+
+function validatePassword (req, res, next) {
+    const { password, confirmPassword } = req.admin;
+
+    if (password !== confirmPassword) {
         const err = new Error(`[Registration Error] Password fields do not match!`);
         err.status = 400;
         return next(err);
     }
 
-    req.admin = new Admin(admin);
+    try {
+        _validatePassword(password);
+    } catch (e) {
+        return next(e);
+    }
+
     next();
 }
 
@@ -35,18 +49,67 @@ function validateFields (req, res, next) {
 function saveAdmin (req, res, next) {
     const { admin } = req;
 
-    admin.save()
+    Admin.create(admin)
         .then((adm) => {
             req.user = adm; // save as user, so that generateToken works
             next();
         })
-        .catch( err => next(err));
+        .catch(err => {
+            const e = new Error(`[Registration Error] Admin already exists`);
+            e.description = `Admin with the email: ${admin.email} already exists`;
+            e.status = err.status;
+            next(e)
+        });
 }
 
-function returnAdmin(req, res, next) {
+function returnAdmin (req, res, next) {
     const { token } = req;
-    res.status(201).json({success: true, token});
+    res.status(201).json({ success: true, token });
+}
+
+function _validatePassword (pwd) {
+
+    if (pwd.length <= 8 || !_passwordContainsNumber(pwd) || !_passwordContainsUppAndLowerCase(pwd)) {
+
+        const err = new Error(`[Registration Error] Password requirements are not met!`);
+        err.description = `Password length must be longer than 8, contain at least one number, and upper- and lower-case letters`;
+        err.status = 400;
+        throw err;
+    } else {
+        return pwd;
+    }
+}
+
+function _passwordContainsNumber (pwd) {
+    const matches = pwd.match(/\d+/g);
+    return matches !== null;
+}
+
+function _passwordContainsUppAndLowerCase (pwd) {
+    let hasUpper = false;
+    let hasLower = false;
+    const pwdLst = pwd.split('');
+
+    for (let c of pwdLst) {
+        // Stop iteration, when these conditions are met
+        if (hasUpper && hasLower) {
+            break;
+        }
+
+        if (_passwordContainsNumber(c)) {
+            continue; // A number can disrupt test, therefore skip if num
+        }
+
+        if (!hasUpper) {
+            hasUpper = !/[A-Z]/.test(c);
+        }
+        if (!hasLower) {
+            hasLower = !/[a-z]/.test(c);
+        }
+    }
+
+    return (hasUpper && hasLower);
 }
 
 
-module.exports = { register };
+module.exports = { register, _validatePassword };

--- a/controllers/admin/remove.js
+++ b/controllers/admin/remove.js
@@ -6,11 +6,13 @@ const remove = [
     returnFeedback
 ];
 
+
 function findAdmin (req, res, next) {
     const { uid } = req.decoded;
 
     Admin.findById(uid)
         .then((admin) => {
+
             if (!admin) {
                 const err = new Error('[Admin Delete Error] Cannot find admin');
                 err.status = 500;

--- a/controllers/admin/remove.js
+++ b/controllers/admin/remove.js
@@ -1,0 +1,42 @@
+const Admin = require('../../models/admin');
+
+const remove = [
+    findAdmin,
+    removeAdmin,
+    returnFeedback
+];
+
+function findAdmin (req, res, next) {
+    const { uid } = req.decoded;
+
+    Admin.findById(uid)
+        .then((admin) => {
+            if (!admin) {
+                const err = new Error('[Admin Delete Error] Cannot find admin');
+                err.status = 500;
+                err.description = 'Admin do not exist, or has probably already been deleted';
+                return next(err);
+            }
+
+            req.admin = admin;
+            next();
+        })
+        .catch(err => next(err));
+}
+
+function removeAdmin (req, res, next) {
+    const { admin } = req;
+
+    Admin.remove({ _id: admin._id })
+        .then(({ result }) => {
+            next();
+        })
+        .catch(err => next(err));
+}
+
+function returnFeedback (req, res, next) {
+    const { admin } = req;
+    res.status(200).json(admin);
+}
+
+module.exports = { remove };

--- a/controllers/admin/update.js
+++ b/controllers/admin/update.js
@@ -1,8 +1,12 @@
 const Admin = require('../../models/admin');
+const { _validatePassword } = require('./register');
 
 const update = [
     validateFields,
-    updateAdmin
+    validatePassword,
+    hashPassword,
+    updateAdmin,
+    returnUpdatedAdmin
 ];
 
 function validateFields (req, res, next) {
@@ -15,6 +19,8 @@ function validateFields (req, res, next) {
         }
     }
 
+    // Ensure if one of the password field exists
+    // the other fields also exists
     if (adm.password || adm.oldPassword || adm.confirmPassword) {
         if (!adm.password || !adm.oldPassword || !adm.confirmPassword) {
             const err = new Error(`[Admin Modify Error] Trying to update password, but missing one or more of the fields 'oldPassword', 'password', 'confirmPassword'`);
@@ -23,20 +29,76 @@ function validateFields (req, res, next) {
         }
     }
 
-    req.admin = new Admin(adm);
+    req.admin = adm;
     next();
 }
 
-function updateAdmin (req, res, next) {
+function validatePassword (req, res, next) {
+    const { uid } = req.decoded;
     const { admin } = req;
 
-    admin.save()
-        .then( (adm) => {
-            console.log(adm);
+    if (admin.password !== admin.confirmPassword) {
+        const err = new Error('[Admin Modify Error] New Password fields do not match');
+        err.status = 400;
+        return next(err);
+    }
+
+    try {
+        _validatePassword(admin.password);
+    } catch (e) {
+        e.message = '[Admin Modify Error] Password requirements are not met';
+        return next(e);
+    }
+
+    Admin.verifyPassword(uid, admin.oldPassword)
+        .then(() => next())
+        .catch((err) => {
+            const e = new Error('[Admin Modify Error] Old password is not valid!');
+            e.status = 403;
+            next(e);
         })
-        .catch( err => next(err));
 }
 
+function hashPassword (req, res, next) {
+    const { admin } = req;
+    if (!admin.password) {
+        return next();
+    }
 
+    Admin.hashField(admin.password)
+        .then((hash) => {
+            req.admin.password = hash;
+            next();
+        })
+        .catch(err => next(err));
+}
+
+function updateAdmin (req, res, next) {
+    const { uid } = req.decoded;
+    const { admin } = req;
+
+    Admin.findOneAndUpdate(
+        { _id: uid },
+        { $set: admin },
+        { new: true })
+        .then((adm) => {
+            if (!adm) {
+                const err = new Error(`[Admin Modify Error] Cannot find current admin`);
+                err.status = 404;
+                throw err;
+            }
+
+            const { firstName, lastName, email, lastActive } = adm;
+            req.admin = { firstName, lastName, email, lastActive }; // Replace the old admin
+            next();
+        })
+        .catch(err => next(err));
+}
+
+function returnUpdatedAdmin (req, res, next) {
+    const { admin } = req;
+
+    res.status(200).json(admin);
+}
 
 module.exports = { update };

--- a/lib/validator (unused)/index.js
+++ b/lib/validator (unused)/index.js
@@ -1,0 +1,3 @@
+const { Password } = require('./password');
+
+module.exports = { Password };

--- a/lib/validator (unused)/password.js
+++ b/lib/validator (unused)/password.js
@@ -1,0 +1,13 @@
+
+function Password(pwd) {
+
+
+
+    return {
+        validate() {
+
+        }
+    }
+}
+
+module.exports = { Password };

--- a/middleware/auth/index.js
+++ b/middleware/auth/index.js
@@ -1,4 +1,50 @@
 const jwt = require('jsonwebtoken');
+const Admin = require('../../models/admin');
+
+const authErr = new Error('[Authentication Error] Invalid token');
+authErr.status = 403;
+
+const requireToken = [
+    validateToken,
+    validateAdmin
+];
+
+function validateToken(req, res, next) {
+    const token = req.body.token ||
+        req.query.token ||
+        req.headers['x-access-token'] ||
+        req.headers['authorization'];
+
+    if (!token) {
+        const err = new Error('[Authentication Error] Missing authorization token');
+        err.status = 403;
+        return next(err);
+    }
+
+    jwt.verify(token, req.config['token-secret'], (err, decoded) => {
+        if (err) {
+            authErr.description = `Token has probably expired`;
+            return next(authErr);
+        }
+
+        req.decoded = decoded;
+        next();
+    });
+}
+
+function validateAdmin(req, res, next) {
+    const { uid } = req.decoded;
+
+    Admin.findById(uid)
+        .then((admin) => {
+            if (!admin) { // If no
+                authErr.description = `Token has no valid admin linked to it`;
+                return next(authErr);
+            }
+            next();
+        })
+        .catch( (err) => next(err));
+}
 
 module.exports = {
 
@@ -7,30 +53,7 @@ module.exports = {
      *
      * Authenticates a request, by validating the provided token
      * */
-    requireToken(req, res, next) {
-        const token = req.body.token ||
-            req.query.token ||
-            req.headers['x-access-token'] ||
-            req.headers['authorization'];
-
-        if (!token) {
-            const err = new Error('Authentication Error: Missing authorization token');
-            err.status = 403;
-            return next(err);
-        }
-
-        jwt.verify(token, req.config['token-secret'], (err, decoded) => {
-            if (err) {
-                const authErr = new Error('Authentication Error: Invalid token');
-                authErr.status = 403;
-                return next(authErr);
-            }
-
-            req.decoded = decoded;
-            next();
-        })
-
-    },
+    requireToken,
 
     /**
      * @param   {object}    pkg     The package to include in the token

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1,8 +1,0 @@
-body {
-  padding: 50px;
-  font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
-}
-
-a {
-  color: #00B7FF;
-}


### PR DESCRIPTION
Ref issue #12.

La også til Sjekk av admin i `requireToken`, slik at ein forhåpentlegvis slepper situasjonar der ein _token_ fortsatt er gyldig, sjølv om Admin brukaren har blitt sletta.

For no ligger _autentisering_ (`POST /token`) under admin-kontrolleren, sidan det er så godt knytta opp mot admin. Men det kan vere mulig at denne seinare blir flytta til ein _autentiseringskontroller_ (`POST /auth/token`), sidan dette er meir beskrivande i ein _URL_