### PR TITLE
Streamline npm run ... (#27)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "watch": "nodemon"
+    "build": "./node_modules/concurrently/src/main.js \"npm start --prefix ./client\" \"npm start\"",
+    "watch": "./node_modules/concurrently/src/main.js \"npm run watch --prefix ./client\" \"nodemon\""
   },
   "dependencies": {
     "bcryptjs": "^2.4.0",
@@ -19,6 +20,7 @@
     "serve-favicon": "~2.3.0"
   },
   "devDependencies": {
+    "concurrently": "^3.1.0",
     "eslint": "^3.13.0",
     "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-import": "^2.2.0"

--- a/setup_packages.sh
+++ b/setup_packages.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+printf "Installing angular cli\n\n"
+npm install -g angular-cli
+
+printf "\nInstalling server packages\n\n"
+npm install
+
+printf "\nInstalling angular packages\n\n"
+npm install --prefix ./client
+
+printf "\nPackages are installed, run \"npm run build or watch\" to start server"
+


### PR DESCRIPTION
No trenger ein bere å køyre `npm run watch` eller `npm run build` på rotmappa for chriba (altså ikkje i _client_). Hugs å køyr `npm install` igjen