### PR TITLE
Implementer XHRService (#8)

### DIFF
--- a/client/src/app/models/XHRError.ts
+++ b/client/src/app/models/XHRError.ts
@@ -1,0 +1,10 @@
+
+export class XHRError extends Error{
+    status: number;
+
+    constructor(err?: string, status?: number) {
+        super(err);
+        this.status = status;
+    }
+
+}

--- a/client/src/app/models/xhr.ts
+++ b/client/src/app/models/xhr.ts
@@ -1,0 +1,5 @@
+
+export interface XHR {
+    url: string;
+    token?: string;
+}

--- a/client/src/app/shared/index.ts
+++ b/client/src/app/shared/index.ts
@@ -1,9 +1,11 @@
 import { AuthService } from './auth/auth.service';
 import { AuthGuard } from './auth/auth.guard';
+import { XHRService } from './xhr.service';
 
 export const SHARED_DECLARATIONS = [];
 
 export const SHARED_PROVIDERS = [
     AuthService,
-    AuthGuard
+    AuthGuard,
+    XHRService
 ];

--- a/client/src/app/shared/xhr.service.ts
+++ b/client/src/app/shared/xhr.service.ts
@@ -1,0 +1,183 @@
+import { Injectable } from '@angular/core';
+import { Headers } from "@angular/http";
+
+export interface XHR {
+    url: string;
+    token?: string;
+}
+
+@Injectable()
+export class XHRService {
+
+    get(opt: XHR, headers?: Headers, body?: FormData | Object): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const xhr = this.initXHR({url: opt.url, token: opt.token, method: 'GET'}, headers);
+
+            xhr.addEventListener('load', () => {
+                try {
+                    let data = this.loadHandler(xhr);
+                    return resolve(data);
+                } catch (e) {
+                    return reject(e);
+                }
+            });
+
+            xhr.addEventListener('error', () => {
+                let err: Error;
+                try {
+                    err = this.errorHandler(xhr);
+                } catch (e) {
+                    err = e;
+                }
+                return reject(err);
+            });
+
+            xhr.send(body);
+        });
+    }
+
+    post(opt: XHR, headers?: Headers, body?: FormData | Object): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const xhr = this.initXHR({url: opt.url, token: opt.token, method: 'POST'}, headers);
+
+            xhr.addEventListener('load', () => {
+                try {
+                    let data = this.loadHandler(xhr);
+                    return resolve(data);
+                } catch (e) {
+                    return reject(e);
+                }
+            });
+
+            xhr.addEventListener('error', () => {
+                let err: Error;
+                try {
+                    err = this.errorHandler(xhr);
+                } catch (e) {
+                    err = e;
+                }
+                return reject(err);
+            });
+
+            xhr.send(body);
+        });
+    }
+
+    put(opt: XHR, headers?: Headers, body?: FormData | Object): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const xhr = this.initXHR({url: opt.url, token: opt.token, method: 'PUT'}, headers);
+
+            xhr.addEventListener('load', () => {
+                try {
+                    let data = this.loadHandler(xhr);
+                    return resolve(data);
+                } catch (e) {
+                    return reject(e);
+                }
+            });
+
+            xhr.addEventListener('error', () => {
+                let err: Error;
+                try {
+                    err = this.errorHandler(xhr);
+                } catch (e) {
+                    err = e;
+                }
+                return reject(err);
+            });
+
+            xhr.send(body);
+        });
+    }
+
+    delete(opt: XHR, headers?: Headers, body?: FormData | Object): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const xhr = this.initXHR({url: opt.url, token: opt.token, method: 'DELETE'}, headers);
+
+            xhr.addEventListener('load', () => {
+                try {
+                    let data = this.loadHandler(xhr);
+                    return resolve(data);
+                } catch (e) {
+                    return reject(e);
+                }
+            });
+
+            xhr.addEventListener('error', () => {
+                let err: Error;
+                try {
+                    err = this.errorHandler(xhr);
+                } catch (e) {
+                    err = e;
+                }
+                return reject(err);
+            });
+
+            xhr.send(body);
+        });
+    }
+
+    private initXHR({url, method, token}, headers: Headers): XMLHttpRequest {
+        let xhr = new XMLHttpRequest();
+        xhr.open(method.toLowerCase(), url);
+        xhr = this.setHeaders(xhr, headers);
+
+        if (token) {
+            xhr.setRequestHeader('Authorization', token);
+        }
+
+        return xhr;
+    }
+
+    private setHeaders(xhr:XMLHttpRequest, headers: Headers): XMLHttpRequest {
+        if (headers) {
+            headers.forEach((val, key) => {
+                xhr.setRequestHeader(key, val[0]);
+            });
+        }
+
+        return xhr;
+    }
+
+
+    private loadHandler(xhr) {
+        let res = xhr.responseText;
+        let data: Object;
+
+        // Convert response to JSON
+        try {
+            data = JSON.parse(res);
+        } catch(e) {
+            throw this.errorHandler(xhr);
+        }
+
+        // Catch error-responses
+        if (xhr.status > 399 || xhr.status < 200) {
+            return this.errorHandler(xhr);
+        }
+
+        return data;
+    }
+
+    private errorHandler(xhr: XMLHttpRequest, data?: Object): Error {
+        let err: Error = new Error();
+
+        let obj;
+        if (data) {
+            obj = data;
+        } else {
+            try {
+                obj = JSON.parse(xhr.responseText);
+            } catch(e) {
+                obj = {error: '[XHR Error] Invalid response format'};
+                err.stack = xhr.responseText; // Put original text in as stack
+            }
+        }
+
+        err.message = obj.error || obj.err || obj || '[XHR Error] Unknown';
+        //noinspection TypeScriptUnresolvedVariable
+        err.status = xhr.status;
+
+        return err;
+    }
+}

--- a/client/src/app/shared/xhr.service.ts
+++ b/client/src/app/shared/xhr.service.ts
@@ -1,10 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Headers } from "@angular/http";
+import { XHRError } from '../models/XHRError';
+import { XHR } from '../models/xhr';
 
-export interface XHR {
-    url: string;
-    token?: string;
-}
 
 @Injectable()
 export class XHRService {
@@ -159,8 +157,8 @@ export class XHRService {
         return data;
     }
 
-    private errorHandler(xhr: XMLHttpRequest, data?: Object): Error {
-        let err: Error = new Error();
+    private errorHandler(xhr: XMLHttpRequest, data?: Object): XHRError {
+        let err = new XHRError();
 
         let obj;
         if (data) {
@@ -175,7 +173,6 @@ export class XHRService {
         }
 
         err.message = obj.error || obj.err || obj || '[XHR Error] Unknown';
-        //noinspection TypeScriptUnresolvedVariable
         err.status = xhr.status;
 
         return err;


### PR DESCRIPTION
Henta frå eit sepparat prosjekt. Koden fungerte der, men er ikkje testa i dette prosjektet.

Denne servicen er meint å brukast rundt handtering av binærfiler (_bildeopplasting osv._), der angular 2 sin service ikkje er like brukarvennleg.

Funksjonskall skjer på nokså lik måte, men med visse forskjellar

```
xhr.get({url: '', token?: ''}, headers?: Headers, body?: FormData | Object)
.then((data) => {
})
.catch((err) => {})
```